### PR TITLE
chore(deps): upgrade AI SDK family (patches last advisory)

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -18,14 +18,14 @@
     "db:down": "docker compose down"
   },
   "dependencies": {
-    "@ai-sdk/google": "^2.0.11",
-    "@ai-sdk/openai": "^2.0.23",
+    "@ai-sdk/google": "^3.0.80",
+    "@ai-sdk/openai": "^3.0.69",
     "@langchain/textsplitters": "^0.1.0",
-    "@openrouter/ai-sdk-provider": "^1.1.2",
+    "@openrouter/ai-sdk-provider": "^2.9.1",
     "@orpc/client": "^1.14.5",
     "@orpc/server": "^1.14.5",
     "@types/redis": "^4.0.11",
-    "ai": "^5.0.27",
+    "ai": "^6.0.201",
     "better-auth": "^1.4.2",
     "dotenv": "^17.2.1",
     "drizzle-orm": "^0.45.2",

--- a/apps/server/src/routers/chat.ts
+++ b/apps/server/src/routers/chat.ts
@@ -79,7 +79,7 @@ export const chatRouter = {
 
     const result = streamText({
       model: openrouter(MODEL),
-      messages: convertToModelMessages(messages),
+      messages: await convertToModelMessages(messages),
       providerOptions: {
         openai: {
           reasoning_effort: 'minimal',
@@ -144,7 +144,7 @@ export const chatRouter = {
 
       const result = streamText({
         model: openrouter(MODEL),
-        messages: convertToModelMessages(messages),
+        messages: await convertToModelMessages(messages),
         providerOptions: {
           openai: {
             reasoning_effort: 'minimal',

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@ai-sdk/react": "^2.0.27",
+    "@ai-sdk/react": "^3.0.203",
     "@orpc/client": "^1.14.5",
     "@orpc/tanstack-query": "^1.14.5",
     "@radix-ui/react-avatar": "^1.1.10",
@@ -25,7 +25,7 @@
     "@radix-ui/react-use-controllable-state": "^1.2.2",
     "@tanstack/react-form": "^1.19.3",
     "@tanstack/react-query": "^5.85.5",
-    "ai": "^5.0.28",
+    "ai": "^6.0.201",
     "better-auth": "^1.4.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/web/src/components/ai-elements/tool.tsx
+++ b/apps/web/src/components/ai-elements/tool.tsx
@@ -35,19 +35,25 @@ export type ToolHeaderProps = {
 };
 
 const getStatusBadge = (status: ToolUIPart['state']) => {
-  const labels = {
+  const labels: Record<ToolUIPart['state'], string> = {
     'input-streaming': 'Pending',
     'input-available': 'Running',
+    'approval-requested': 'Awaiting approval',
+    'approval-responded': 'Approval responded',
     'output-available': 'Completed',
     'output-error': 'Error',
-  } as const;
+    'output-denied': 'Denied',
+  };
 
-  const icons = {
+  const icons: Record<ToolUIPart['state'], ReactNode> = {
     'input-streaming': <CircleIcon className="size-4" />,
     'input-available': <ClockIcon className="size-4 animate-pulse" />,
+    'approval-requested': <ClockIcon className="size-4 animate-pulse" />,
+    'approval-responded': <ClockIcon className="size-4 animate-pulse" />,
     'output-available': <CheckCircleIcon className="size-4 text-green-600" />,
     'output-error': <XCircleIcon className="size-4 text-red-600" />,
-  } as const;
+    'output-denied': <XCircleIcon className="size-4 text-red-600" />,
+  };
 
   return (
     <Badge className="gap-1.5 rounded-full text-xs" variant="secondary">

--- a/bun.lock
+++ b/bun.lock
@@ -21,14 +21,14 @@
       "name": "server",
       "version": "0.1.0",
       "dependencies": {
-        "@ai-sdk/google": "^2.0.11",
-        "@ai-sdk/openai": "^2.0.23",
+        "@ai-sdk/google": "^3.0.80",
+        "@ai-sdk/openai": "^3.0.69",
         "@langchain/textsplitters": "^0.1.0",
-        "@openrouter/ai-sdk-provider": "^1.1.2",
+        "@openrouter/ai-sdk-provider": "^2.9.1",
         "@orpc/client": "^1.14.5",
         "@orpc/server": "^1.14.5",
         "@types/redis": "^4.0.11",
-        "ai": "^5.0.27",
+        "ai": "^6.0.201",
         "better-auth": "^1.4.2",
         "dotenv": "^17.2.1",
         "drizzle-orm": "^0.45.2",
@@ -55,7 +55,7 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
-        "@ai-sdk/react": "^2.0.27",
+        "@ai-sdk/react": "^3.0.203",
         "@orpc/client": "^1.14.5",
         "@orpc/tanstack-query": "^1.14.5",
         "@radix-ui/react-avatar": "^1.1.10",
@@ -72,7 +72,7 @@
         "@radix-ui/react-use-controllable-state": "^1.2.2",
         "@tanstack/react-form": "^1.19.3",
         "@tanstack/react-query": "^5.85.5",
-        "ai": "^5.0.28",
+        "ai": "^6.0.201",
         "better-auth": "^1.4.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -149,17 +149,17 @@
     "yaml": ">=2.8.3",
   },
   "packages": {
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.98", "", { "dependencies": { "@ai-sdk/provider": "2.0.3", "@ai-sdk/provider-utils": "3.0.25", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-JNMc5Fbz8AwiLIR3Ar/lV2egbLFE+A5nfwbRKrdfgusoVN2VjgMX2U2KCLux5iWD/Q9+rg9+njHPZNw4HmzBJQ=="],
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.127", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Obmw5hmE5x+ccRrMp/Djx5r0rpFVX87YqE6OY06g5fwYlRI30dA84ARfTzX45ivCvkW4eCnBpOVXVWQ/pjH85w=="],
 
-    "@ai-sdk/google": ["@ai-sdk/google@2.0.74", "", { "dependencies": { "@ai-sdk/provider": "2.0.3", "@ai-sdk/provider-utils": "3.0.25" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Lhw1742RXc+4pRIvqVXa0jdl5+qdpmw8lj0lm6OchUg9rVGHzymlaxe7CDiYX5U2af4jbjKeTY22LDi3bIycgQ=="],
+    "@ai-sdk/google": ["@ai-sdk/google@3.0.80", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-5ORbm/yFUPO0MEvZsxBMN0cdKw2+lwU/wVn5KN3KF8Dmk1LughuDuUohMh/7iU/XFTiyB0OvmTW/tdV/J7O9zg=="],
 
-    "@ai-sdk/openai": ["@ai-sdk/openai@2.0.106", "", { "dependencies": { "@ai-sdk/provider": "2.0.3", "@ai-sdk/provider-utils": "3.0.25" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-EFC0rpo1wfe4HIz5KZCE72edP2J7fOeR7wPXzjCDljaTRB1wectKDIKRLowpU4F0mbcJ+XScAsoYNPK/Z20aVQ=="],
+    "@ai-sdk/openai": ["@ai-sdk/openai@3.0.69", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-T/J3ED6ERDsine+crkXHfraisSG20k6BkBdgjvXCvySYnnJ19IaLIOsQPYfvXdOsKrl0LVNghooTV/nKCA7SmQ=="],
 
-    "@ai-sdk/provider": ["@ai-sdk/provider@2.0.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww=="],
+    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
 
-    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.25", "", { "dependencies": { "@ai-sdk/provider": "2.0.3", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CvsRu+32Y8a167s+lrIBtsybvgTHp8j9y+6BeTvLeoW3Q+okw/b4CnNUFOLIXsRaKHQKAH+IHNJPYWywfpw0LA=="],
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.27", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw=="],
 
-    "@ai-sdk/react": ["@ai-sdk/react@2.0.200", "", { "dependencies": { "@ai-sdk/provider-utils": "3.0.25", "ai": "5.0.198", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1", "zod": "^3.25.76 || ^4.1.8" }, "optionalPeers": ["zod"] }, "sha512-QQRTZU3Nc+fECMaexv28B9Yb1/uJ8VU89gyevC7aeZq9lDagWQUWqmy6i4I6Vj1oWQ/EO8bXb1g/GOFwrWDT9g=="],
+    "@ai-sdk/react": ["@ai-sdk/react@3.0.203", "", { "dependencies": { "@ai-sdk/provider-utils": "4.0.27", "ai": "6.0.201", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-6YcuOw50Ay/q21FXytEaRDXsabEqwpp8YcJ+moEaImyQpd94OKEqFEDs62jLHkK8gW6Xw9nmKNSNpCglsHAJ4g=="],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
@@ -495,9 +495,7 @@
 
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
-    "@openrouter/ai-sdk-provider": ["@openrouter/ai-sdk-provider@1.5.4", "", { "dependencies": { "@openrouter/sdk": "^0.1.27" }, "peerDependencies": { "ai": "^5.0.0", "zod": "^3.24.1 || ^v4" } }, "sha512-xrSQPUIH8n9zuyYZR0XK7Ba0h2KsjJcMkxnwaYfmv13pKs3sDkjPzVPPhlhzqBGddHb5cFEwJ9VFuFeDcxCDSw=="],
-
-    "@openrouter/sdk": ["@openrouter/sdk@0.1.27", "", { "dependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-RH//L10bSmc81q25zAZudiI4kNkLgxF2E+WU42vghp3N6TEvZ6F0jK7uT3tOxkEn91gzmMw9YVmDENy7SJsajQ=="],
+    "@openrouter/ai-sdk-provider": ["@openrouter/ai-sdk-provider@2.9.1", "", { "peerDependencies": { "ai": "^6.0.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-okgq07Vdkro4CB5INbfhwa0e6VR1HS7sidNcfHN/MeXLJvX1JmQCff/vem6tcxwT9r1avyFrXSlfv9B28D/Pag=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
@@ -903,7 +901,7 @@
 
     "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
 
-    "@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
+    "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
 
     "@vitest/expect": ["@vitest/expect@4.1.8", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.8", "@vitest/utils": "4.1.8", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ=="],
 
@@ -923,7 +921,7 @@
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
-    "ai": ["ai@5.0.198", "", { "dependencies": { "@ai-sdk/gateway": "2.0.98", "@ai-sdk/provider": "2.0.3", "@ai-sdk/provider-utils": "3.0.25", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-aKYgLRZpxJOaorTHHSPdlfMc+LRX9n6KVr1MTrEm3rJ7rbymxcYCcoOWs1JRfZvxXgguwIxGREHEXT6ubOEwxw=="],
+    "ai": ["ai@6.0.201", "", { "dependencies": { "@ai-sdk/gateway": "3.0.127", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@opentelemetry/api": "^1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-iDmXSy7csk+SYaCkTUMwsOE/73pksR1spctV+u+DW97v+R/Cj01gchgCUNVrn9QyNHqOJQuTg+JBVsBsp6lOag=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 


### PR DESCRIPTION
Coordinated upgrade of the ai/@ai-sdk/* family to clear the remaining @ai-sdk/provider-utils advisory. Includes any source changes needed for the new SDK API. Build + typecheck verified green. Review runtime behavior of chat/streaming before deploy.

## Version bumps (coordinated, all resolve to a single @ai-sdk/provider-utils@4.0.27)
- ai: ^5.0.27/^5.0.28 -> ^6.0.201
- @ai-sdk/react: ^2.0.27 -> ^3.0.203
- @ai-sdk/openai: ^2.0.23 -> ^3.0.69
- @ai-sdk/google: ^2.0.11 -> ^3.0.80
- @openrouter/ai-sdk-provider: ^1.1.2 -> ^2.9.1

The whole family now agrees on @ai-sdk/provider-utils@4.0.27 and @ai-sdk/provider@3.0.10 (the version skew that broke the prior attempt is gone).

## Source changes for the v6 API
- `apps/server/src/routers/chat.ts` — `convertToModelMessages` is now async in v6; await it at both streamText call sites.
- `apps/web/src/components/ai-elements/tool.tsx` — v6's `ToolUIPart['state']` union added `approval-requested`, `approval-responded`, `output-denied`; made the status label/icon maps exhaustive (typed as `Record<ToolUIPart['state'], …>`).

## Verification
- `bun run build` (turbo, both web + server Next.js apps): pass
- `tsc --noEmit` per app: pass